### PR TITLE
[Feat] 음식 조회 로직 수정 #75

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+	implementation 'info.debatty:java-string-similarity:1.2.1'
+
 	//S3
 	implementation platform('software.amazon.awssdk:bom:2.25.32') // 최신 BOM을 먼저 지정 (버전 맞춰줌)
 	implementation 'software.amazon.awssdk:s3'

--- a/src/main/java/com/daall/howtoeat/client/food/FoodController.java
+++ b/src/main/java/com/daall/howtoeat/client/food/FoodController.java
@@ -21,11 +21,11 @@ public class FoodController {
     public ResponseEntity<ResponseDataDto<ScrollResponseDto<FoodResponseDto>>> getFoods(
             @RequestParam(required = false) String name,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "20") int size
     ) {
             System.out.println("Controller");
 
-            ScrollResponseDto<FoodResponseDto> result = foodService.getFoods(name, page, size);
+            ScrollResponseDto<FoodResponseDto> result = foodService.searchSimilarFoods(name, page, size);
 
             SuccessType successType = SuccessType.GET_ALL_FOODS_SUCCESS;
 
@@ -39,6 +39,5 @@ public class FoodController {
             SuccessType successType = SuccessType.GET_FOOD_SUCCESS;
             FoodResponseDto responseDto = foodService.getFood(foodId);
             return ResponseEntity.status(successType.getHttpStatus()).body(new ResponseDataDto<>(successType, responseDto));
-
     }
 }

--- a/src/main/java/com/daall/howtoeat/client/food/FoodRepository.java
+++ b/src/main/java/com/daall/howtoeat/client/food/FoodRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,4 +24,8 @@ public interface FoodRepository extends JpaRepository<Food, Long>, FoodRepositor
     Optional<Food> findByFoodCode(String foodCode);
 
     long countByFoodTypeIn(List<FoodType> ingredient);
+
+    @Query("SELECT f FROM Food f WHERE f.foodName LIKE %:raw% OR f.foodName LIKE %:trimmed%")
+    List<Food> findByNameContainingVariants(@Param("raw") String raw, @Param("trimmed") String trimmed);
+
 }


### PR DESCRIPTION
## 4. 🧠 Jaro-Winkler 유사도 기반 Java 정렬

### ✅ 방식

- DB에서 `LIKE`로 1차 후보군 조회 (공백 포함 및 제거한 키워드 모두 검색)
- Java에서 Jaro-Winkler Distance를 사용해 유사도 계산
- 유사도 높은 순으로 정렬
- tie-breaker로 `foodType` 정렬 추가 (COOKED > PROCESSED > 기타)

```java
java
복사편집
.sorted(Comparator
    .comparingDouble((Food f) -> jw.similarity(input, f.getFoodName()))
    .reversed()
    .thenComparing(f -> foodTypeOrder(f.getFoodType()))
)

```

### ✅ 장점

- **정확한 유사도 기반 정렬** 가능
- `"김치"`와 `"김 치"` 문제 해결 가능 (공백 제거 키워드 함께 검색)
- 확장성: 유사도 기준 다양화, tie-breaker 추가 가능

### ❌ 단점

- **모든 후보군을 자바로 가져온 뒤 연산** → 대용량 시 성능 저하 우려
- JPA의 `Pageable`을 쓰면 정렬 전에 잘리므로, 직접 페이징 처리 필요

### 🔧 대응 방법

- `LIKE`로 가져오는 후보군에 제한 (`LIMIT 5000` 등)
- 향후 Redis 캐싱 or ElasticSearch 도입 고려