### PR TITLE
[Fix] admin에서 userDailySummary / ConsumedFood의 정보 조회 시, registerdAt 활…

### DIFF
--- a/src/main/java/com/daall/howtoeat/admin/consumedfood/AdminConsumedFoodService.java
+++ b/src/main/java/com/daall/howtoeat/admin/consumedfood/AdminConsumedFoodService.java
@@ -53,7 +53,7 @@ public class AdminConsumedFoodService {
         List<ConsumedFoodResponseDto> snackConsumedFoods = new ArrayList<>();
 
         for(MealTime mealTime : MealTime.values()) {
-            List<ConsumedFood> consumedFoods = consumedFoodRepository.findAllByUserAndCreatedAtBetweenAndMealTime(user, start, end, mealTime);
+            List<ConsumedFood> consumedFoods = consumedFoodRepository.findAllByUserAndRegisteredAtAndMealTime(user, date, mealTime);
 
             for(ConsumedFood consumedFood : consumedFoods) {
                 if(mealTime.equals(MealTime.BREAKFAST)) {

--- a/src/main/java/com/daall/howtoeat/admin/userdailysummary/AdminUserDailySummaryService.java
+++ b/src/main/java/com/daall/howtoeat/admin/userdailysummary/AdminUserDailySummaryService.java
@@ -53,13 +53,11 @@ public class AdminUserDailySummaryService {
      *
      */
     public DailyMacrosWithDatesResponseDto getUserDailySummaryMacrosWithDates(Long userId, LocalDate date) {
-        LocalDateTime start = date.atStartOfDay();
-        LocalDateTime end   = date.atTime(LocalTime.MAX);
 
         User user = userService.getUser(userId);
 
         // 현재 날짜의 매크로
-        UserDailySummary summary = userDailySummaryRepository.findByUserAndCreatedAtBetween(user, start, end).orElse(null);
+        UserDailySummary summary = userDailySummaryRepository.findByUserAndRegisteredAt(user, date).orElse(null);
         UserTarget target = userTargetService.getLatestTargetBeforeOrOn(user, date);
 
         DailyConsumedMacrosResponseDto macros =
@@ -69,13 +67,13 @@ public class AdminUserDailySummaryService {
 
         // 이전 / 다음 날짜 조회
         String prevDate = userDailySummaryRepository
-                .findTopByUserAndCreatedAtBeforeOrderByCreatedAtDesc(user, start)
-                .map(s -> s.getCreatedAt().toLocalDate().toString())
+                .findTopByUserAndRegisteredAtBeforeOrderByRegisteredAtDesc(user, date)
+                .map(s -> s.getRegisteredAt().toString())
                 .orElse(null);
 
         String nextDate = userDailySummaryRepository
-                .findTopByUserAndCreatedAtAfterOrderByCreatedAtAsc(user, end)
-                .map(s -> s.getCreatedAt().toLocalDate().toString())
+                .findTopByUserAndRegisteredAtAfterOrderByRegisteredAtAsc(user, date)
+                .map(s -> s.getRegisteredAt().toString())
                 .orElse(null);
 
         List<String> dates = Arrays.asList(prevDate, nextDate);
@@ -91,11 +89,11 @@ public class AdminUserDailySummaryService {
      *
      */
     public DailySummariesByMealTimeResponseDto getUserDailySummaryByMealTimes(Long userId, LocalDate date) {
-        LocalDateTime start = date.atStartOfDay();
-        LocalDateTime end = date.atTime(23, 59, 59);
+//        LocalDateTime start = date.atStartOfDay();
+//        LocalDateTime end = date.atTime(23, 59, 59);
         User user = userService.getUser(userId);
 
-        UserDailySummary summary = userDailySummaryRepository.findByUserAndCreatedAtBetween(user, start, end).orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_USER_DAILY_SUMMARY));
+        UserDailySummary summary = userDailySummaryRepository.findByUserAndRegisteredAt(user, date).orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_USER_DAILY_SUMMARY));
 
         DailyConsumedMacrosByMealTimeResponseDto breakfast = new DailyConsumedMacrosByMealTimeResponseDto(summary, MealTime.BREAKFAST);
         DailyConsumedMacrosByMealTimeResponseDto lunch = new DailyConsumedMacrosByMealTimeResponseDto(summary, MealTime.LUNCH);

--- a/src/main/java/com/daall/howtoeat/admin/userdailysummary/dto/DailyCaloriesSummaryDto.java
+++ b/src/main/java/com/daall/howtoeat/admin/userdailysummary/dto/DailyCaloriesSummaryDto.java
@@ -12,7 +12,7 @@ public class DailyCaloriesSummaryDto {
     private final Double lunchKcal;
     private final Double dinnerKcal;
     private final Double snackKcal;
-    private final LocalDate createdAt;
+    private final LocalDate registeredAt;
 
     public DailyCaloriesSummaryDto(UserDailySummary userDailySummary) {
         this.id = userDailySummary.getId();
@@ -21,6 +21,6 @@ public class DailyCaloriesSummaryDto {
         this.lunchKcal = userDailySummary.getLunchKcal();
         this.dinnerKcal = userDailySummary.getDinnerKcal();
         this.snackKcal = userDailySummary.getSnackKcal();
-        this.createdAt = userDailySummary.getCreatedAt().toLocalDate();
+        this.registeredAt = userDailySummary.getRegisteredAt();
     }
 }

--- a/src/main/java/com/daall/howtoeat/client/userdailysummary/UserDailySummaryRepository.java
+++ b/src/main/java/com/daall/howtoeat/client/userdailysummary/UserDailySummaryRepository.java
@@ -23,8 +23,11 @@ public interface UserDailySummaryRepository extends JpaRepository<UserDailySumma
     Optional<UserDailySummary> findByUserAndRegisteredAt(User user, LocalDate date);
     // 이전(과거) 중 가장 최신
     Optional<UserDailySummary> findTopByUserAndCreatedAtBeforeOrderByCreatedAtDesc(User user, LocalDateTime before);
+
+    Optional<UserDailySummary> findTopByUserAndRegisteredAtBeforeOrderByRegisteredAtDesc(User user, LocalDate date);
     // 다음(미래) 중 가장 빠른
     Optional<UserDailySummary> findTopByUserAndCreatedAtAfterOrderByCreatedAtAsc(User user, LocalDateTime after);
+    Optional<UserDailySummary> findTopByUserAndRegisteredAtAfterOrderByRegisteredAtAsc(User user, LocalDate date);
 
     //회원탈퇴 시 연관관계 끊기
     void deleteAllByUser(User user);
@@ -32,12 +35,12 @@ public interface UserDailySummaryRepository extends JpaRepository<UserDailySumma
     @Query(value = """
     SELECT COUNT(*) AS consecutive_days
     FROM (
-        SELECT created_at,
-               ROW_NUMBER() OVER (ORDER BY DATE(created_at) DESC) AS rn,
-               DATEDIFF(:baseDate, DATE(created_at)) AS diff
+        SELECT registered_at,
+               ROW_NUMBER() OVER (ORDER BY DATE(registered_at) DESC) AS rn,
+               DATEDIFF(:baseDate, DATE(registered_at)) AS diff
         FROM user_daily_summaries
         WHERE user_id = :userId
-          AND DATE(created_at) <= :baseDate
+          AND DATE(registered_at) <= :baseDate
     ) AS sub
     WHERE diff = rn - 1
     """, nativeQuery = true)


### PR DESCRIPTION
…용 #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 일일 요약과 섭취 기록을 생성시간이 아닌 등록일 기준으로 조회해 자정 경계에서의 누락/중복 문제를 해소했습니다.
  * 식사 시간대별 조회가 날짜+식사시간 기준으로 더 정확하게 표시됩니다.
  * 이전/다음 날짜 이동 시 올바른 기준일을 사용해 잘못된 이동이 발생하던 문제를 수정했습니다.
  * 연속 기록(스트릭) 계산을 등록일 기준으로 일관되게 반영해 표시 오류를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->